### PR TITLE
Fix payment permission for authorized waiters

### DIFF
--- a/public/payment.php
+++ b/public/payment.php
@@ -2,7 +2,7 @@
 // public/payment.php
 require __DIR__ . '/../config/init.php';
 require __DIR__ . '/../src/auth.php';
-requireRole(['Admin','Garson']);
+requireRole(['Admin','Garson', 'Garson (Yetkili)']);
 
 // 1) Parametre olarak order ID
 $order_id = (int)($_GET['order'] ?? 0);


### PR DESCRIPTION
## Summary
- allow `Garson (Yetkili)` role to complete payments

## Testing
- `php -l payment.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685cce7eaa108320a591c97d348b2617