### PR TITLE
Fix product search not filtering

### DIFF
--- a/public/order_add.php
+++ b/public/order_add.php
@@ -45,3 +45,18 @@ $products = $stmt->fetchAll(PDO::FETCH_ASSOC);
         <?php endforeach; ?>
     </div>
 </section>
+<script>
+  // Basit arama filtrasyonu (doğrudan sayfa yüklendiğinde)
+  document.addEventListener('DOMContentLoaded', function () {
+    const searchInput = document.getElementById('productSearch');
+    if (searchInput) {
+      searchInput.addEventListener('input', function () {
+        const term = this.value.toLowerCase();
+        document.querySelectorAll('#productGrid .product-item').forEach(function (item) {
+          const name = item.dataset.name.toLowerCase();
+          item.style.display = name.includes(term) ? '' : 'none';
+        });
+      });
+    }
+  });
+</script>


### PR DESCRIPTION
## Summary
- add client-side search filtering in `order_add.php`

## Testing
- `php -l public/order_add.php` *(fails: php missing)*

------
https://chatgpt.com/codex/tasks/task_e_685cd6deec9c83209417bb423eaf9898