### PR TITLE
Fix product search not filtering

### DIFF
--- a/public/order_add.php
+++ b/public/order_add.php
@@ -29,8 +29,8 @@ $products = $stmt->fetchAll(PDO::FETCH_ASSOC);
 <section class="mb-4">
     <div class="row g-3" id="productGrid">
         <?php foreach ($products as $p): ?>
-            <div class="col-12 col-sm-6 col-md-4 col-lg-3 product-item">
-                <div class="card shadow-sm rounded-4" style="cursor: pointer;" data-name="<?= htmlspecialchars($p['name']) ?>">
+            <div class="col-12 col-sm-6 col-md-4 col-lg-3 product-item" data-name="<?= htmlspecialchars($p['name']) ?>">
+                <div class="card shadow-sm rounded-4" style="cursor: pointer;">
                     <img src="<?= htmlspecialchars($p['image']) ?>" class="card-img-top" alt="<?= htmlspecialchars($p['name']) ?>" style="height: 200px; object-fit: cover;">
                     <div class="card-body text-center">
                         <h5 class="card-title"><?= htmlspecialchars($p['name']) ?></h5>
@@ -45,3 +45,18 @@ $products = $stmt->fetchAll(PDO::FETCH_ASSOC);
         <?php endforeach; ?>
     </div>
 </section>
+<script>
+  // Basit arama filtrasyonu (doğrudan sayfa yüklendiğinde)
+  document.addEventListener('DOMContentLoaded', function () {
+    const searchInput = document.getElementById('productSearch');
+    if (searchInput) {
+      searchInput.addEventListener('input', function () {
+        const term = this.value.toLowerCase();
+        document.querySelectorAll('#productGrid .product-item').forEach(function (item) {
+          const name = item.dataset.name.toLowerCase();
+          item.style.display = name.includes(term) ? '' : 'none';
+        });
+      });
+    }
+  });
+</script>


### PR DESCRIPTION
## Summary
- put `data-name` attribute on `.product-item` container so the script can find it

## Testing
- `php -l public/order_add.php` *(fails: php missing)*

------
https://chatgpt.com/codex/tasks/task_e_685cd6deec9c83209417bb423eaf9898