### PR TITLE
Fix table occupancy on empty orders

### DIFF
--- a/public/order.php
+++ b/public/order.php
@@ -32,8 +32,8 @@ $stmt->execute([$table_id]);
 $order = $stmt->fetch();
 if (!$order) {
     $pdo->prepare("INSERT INTO orders (table_id) VALUES (?)")->execute([$table_id]);
+    // Table status will be set to occupied when the first product is added
     $order_id = $pdo->lastInsertId();
-    $pdo->prepare("UPDATE pos_tables SET status = 'occupied', opened_at = NOW() WHERE id = ?")->execute([$table_id]);
 } else {
     $order_id = $order['id'];
 }
@@ -53,7 +53,7 @@ if (isset($_POST['add_product'])) {
     }
 
     // Masa durumu güncelleme
-    $pdo->prepare("UPDATE pos_tables SET status = 'occupied' WHERE id = ? AND opened_at IS NULL")->execute([$table_id]);
+    $pdo->prepare("UPDATE pos_tables SET status = 'occupied', opened_at = NOW() WHERE id = ? AND opened_at IS NULL")->execute([$table_id]);
 
     header("Location: order.php?table={$table_id}");
     exit;


### PR DESCRIPTION
## Summary
- remove immediate table occupation when a new order is created
- mark the table as occupied only when the first product is added

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685d27fa3b58832080247cfde98ce8ee