### PR TITLE
Fix mobile horizontal overflow

### DIFF
--- a/public/assets/css/styleson.css
+++ b/public/assets/css/styleson.css
@@ -79,6 +79,7 @@ body {
   line-height: 1.6;
   font-size: 16px;
   min-height: 100vh;
+  overflow-x: hidden;
   transition: background-color 0.3s ease, color 0.3s ease;
 }
 


### PR DESCRIPTION
## Summary
- prevent horizontal scrolling on mobile by hiding overflow

## Testing
- `php -l` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d4489a1d08320a26ef3e6240886c7