### PR TITLE
Add red background to timer for occupied tables

### DIFF
--- a/public/pos.php
+++ b/public/pos.php
@@ -28,7 +28,7 @@ include __DIR__ . '/../src/header.php';
             </span>
           </div>
           <?php if ($t['status'] === 'occupied' && !empty($t['opened_at'])): ?>
-            <div class="table-timer mt-2 text-danger small" data-opened-at="<?= htmlspecialchars($t['opened_at']) ?>"></div>
+            <div class="table-timer badge bg-danger text-white small mt-2" data-opened-at="<?= htmlspecialchars($t['opened_at']) ?>"></div>
           <?php endif; ?>
         </div>
         <?php if ($t['status'] === 'occupied'): ?>


### PR DESCRIPTION
## Summary
- style timer in `pos.php` with a red badge like the "Dolu" label

## Testing
- `php -l public/pos.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4bf203c48320a4431f7ac41b5d78