### PR TITLE
Adjust POS table layout for mobile

### DIFF
--- a/public/assets/css/styleson.css
+++ b/public/assets/css/styleson.css
@@ -622,6 +622,11 @@ input:focus, select:focus, textarea:focus, .form-control:focus, .form-select:foc
     width: 100% !important;
     max-width: 100% !important;
   }
+  /* POS sayfasında iki kart yan yana görünmeli */
+  .col-6 {
+    flex: 0 0 50% !important;
+    max-width: 50% !important;
+  }
 }
 
 /* Ekstra küçük ekranlar için */

--- a/public/pos.php
+++ b/public/pos.php
@@ -13,7 +13,7 @@ include __DIR__ . '/../src/header.php';
 <h2 class="my-3 text-center">Masalar</h2>
 <div class="row g-3">
   <?php foreach ($tables as $t): ?>
-    <div class="col-12 col-sm-6 col-md-4 col-lg-3">
+    <div class="col-6 col-sm-6 col-md-4 col-lg-3">
       <div class="card h-100 shadow-sm rounded-4 text-center position-relative" 
            style="cursor:pointer;"
            onclick="window.location='order.php?table=<?= $t['id'] ?>'">


### PR DESCRIPTION
## Summary
- show two tables per row even on extra-small screens by overriding grid widths in styles

## Testing
- `php -l public/pos.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4d22b6248320af1a1f904346f6d5