### PR TITLE
Refine add-product modal behavior

### DIFF
--- a/public/order.php
+++ b/public/order.php
@@ -447,7 +447,7 @@ include __DIR__ . '/../src/header.php';
 
 <!-- Popup Modal -->
 <div class="modal" tabindex="-1" id="addProductModal">
-    <div class="modal-dialog modal-lg">
+    <div class="modal-dialog modal-xl">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">
@@ -466,6 +466,8 @@ include __DIR__ . '/../src/header.php';
 <?php include __DIR__ . '/../src/footer.php'; ?>
 
 <script>
+let productModal;
+
 function initQuantityButtons(container) {
     container.querySelectorAll('.quantity-box').forEach(box => {
         const input = box.querySelector('.quantity-input');
@@ -511,8 +513,10 @@ function openAddProductModal(categoryId = 0) {
             const modalTitle = document.querySelector('.modal-title');
             modalTitle.innerHTML = '<span class="material-icons me-2">restaurant_menu</span>\u00dcr\u00fcn Seçin';
 
-            const modal = new bootstrap.Modal(document.getElementById('addProductModal'), {keyboard:false});
-            modal.show();
+            if (!productModal) {
+                productModal = new bootstrap.Modal(document.getElementById('addProductModal'), {keyboard:false});
+            }
+            productModal.show();
 
             attachModalEvents(modalBody);
         })

--- a/public/order_add.php
+++ b/public/order_add.php
@@ -70,9 +70,9 @@ $products = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 .products-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
     gap: 1.5rem;
     margin-top: 1.5rem;
+    grid-template-columns: repeat(4, 1fr);
 }
 
 .product-card {
@@ -207,6 +207,17 @@ $products = $stmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
 /* Responsive Design */
+@media (min-width: 992px) {
+    .products-grid {
+        grid-template-columns: repeat(4, 1fr);
+    }
+}
+
+@media (min-width: 768px) and (max-width: 991.98px) {
+    .products-grid {
+        grid-template-columns: repeat(3, 1fr);
+    }
+}
 @media (max-width: 768px) {
     .products-grid {
         grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));


### PR DESCRIPTION
## Summary
- make product selection modal extra wide
- reuse modal instance when reloading products

## Testing
- `php -l public/order.php` *(fails: php not installed)*
- `php -l public/order_add.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d6467ba5c8320a6679fb3b52cf43a