### PR TITLE
Enable removing product images

### DIFF
--- a/public/assets/css/styleson.css
+++ b/public/assets/css/styleson.css
@@ -292,7 +292,11 @@ body {
 }
 
 /* Formlar ve Inputlar - Geliştirilmiş */
-input, select, textarea, .form-control, .form-select {
+input:not([type="checkbox"]):not([type="radio"]),
+select,
+textarea,
+.form-control,
+.form-select {
   background: var(--input-bg) !important;
   color: var(--text) !important;
   border: 2px solid var(--border-color) !important;
@@ -316,6 +320,10 @@ input:focus, select:focus, textarea:focus, .form-control:focus, .form-select:foc
 }
 
 .form-check-input {
+  width: 1em;
+  height: 1em;
+  padding: 0;
+  margin-right: 0.5rem;
   border-radius: 6px;
   border: 2px solid var(--border-color);
 }


### PR DESCRIPTION
## Summary
- allow removing old product images by checkbox
- delete the existing file on replace or when checkbox checked
- tweak form-check CSS and markup so checkbox aligns and shows tick

## Testing
- `php -l public/products_edit.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d6d2347108320b33371811d3add6f