### PR TITLE
Restrict payment actions to authorized roles

### DIFF
--- a/public/order.php
+++ b/public/order.php
@@ -414,7 +414,7 @@ include __DIR__ . '/../src/header.php';
     <?php endif; ?>
 </div>
 
-<?php if (!empty($items)): ?>
+<?php if (!empty($items) && (($_SESSION['user_role'] === 'Admin') || ($_SESSION['user_role'] === 'Garson (Yetkili)'))): ?>
 <a href="payment.php?order=<?= $order_id ?>" class="payment-button">
     <span class="material-icons">payment</span>
     Ödeme Al & Masayı Kapat

--- a/public/payment.php
+++ b/public/payment.php
@@ -2,7 +2,7 @@
 // public/payment.php
 require __DIR__ . '/../config/init.php';
 require __DIR__ . '/../src/auth.php';
-requireRole(['Admin','Garson', 'Garson (Yetkili)']);
+requireRole(['Admin', 'Garson (Yetkili)']);
 
 // 1) Parametre olarak order ID
 $order_id = (int)($_GET['order'] ?? 0);


### PR DESCRIPTION
## Summary
- restrict the payment page so only `Admin` and `Garson (Yetkili)` roles can access it
- show the **Ödeme Al & Masayı Kapat** button on orders only to these authorized roles

## Testing
- `php` binary not available, so no tests were run

------
https://chatgpt.com/codex/tasks/task_e_685d7080726c832084e3de48190b151b