### PR TITLE
Implement polling for realtime order updates

### DIFF
--- a/public/api_order_version.php
+++ b/public/api_order_version.php
@@ -1,0 +1,25 @@
+<?php
+require __DIR__ . '/../config/init.php';
+require __DIR__ . '/../src/auth.php';
+requireRole(['Admin', 'Garson', 'Garson (Yetkili)']);
+
+$table_id = (int)($_GET['table'] ?? 0);
+if (!$table_id) {
+    http_response_code(400);
+    echo json_encode(['error' => 'invalid table']);
+    exit;
+}
+
+$stmt = $pdo->prepare("SELECT id FROM orders WHERE table_id = ? AND status = 'open' LIMIT 1");
+$stmt->execute([$table_id]);
+$order_id = $stmt->fetchColumn();
+
+$items = [];
+if ($order_id) {
+    $stmtItems = $pdo->prepare("SELECT product_id, quantity FROM order_items WHERE order_id = ? ORDER BY id");
+    $stmtItems->execute([$order_id]);
+    $items = $stmtItems->fetchAll(PDO::FETCH_ASSOC);
+}
+
+header('Content-Type: application/json');
+echo json_encode(['version' => sha1(json_encode($items))]);

--- a/public/api_tables_status.php
+++ b/public/api_tables_status.php
@@ -1,0 +1,9 @@
+<?php
+require __DIR__ . '/../config/init.php';
+require __DIR__ . '/../src/auth.php';
+requireRole(['Admin', 'Garson', 'Garson (Yetkili)']);
+
+$tables = $pdo->query("SELECT id, status, opened_at FROM pos_tables ORDER BY id")->fetchAll(PDO::FETCH_ASSOC);
+
+header('Content-Type: application/json');
+echo json_encode($tables);

--- a/public/order.php
+++ b/public/order.php
@@ -118,6 +118,8 @@ if ($_SESSION['user_role'] === 'Admin' && !empty($items)) {
     $itemLogs = $logStmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
+$orderVersion = sha1(json_encode($items));
+
 include __DIR__ . '/../src/header.php';
 ?>
 
@@ -527,4 +529,24 @@ function openAddProductModal(categoryId = 0) {
 }
 
 document.getElementById('openAddProduct').addEventListener('click', () => openAddProductModal());
+</script>
+
+<script>
+  let orderVersion = "<?= $orderVersion ?>";
+  async function checkOrderUpdates() {
+    try {
+      const resp = await fetch('api_order_version.php?table=<?= $table_id ?>');
+      const data = await resp.json();
+      if (orderVersion && data.version !== orderVersion) {
+        location.reload();
+      } else {
+        orderVersion = data.version;
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  }
+  document.addEventListener('DOMContentLoaded', () => {
+    setInterval(checkOrderUpdates, 5000);
+  });
 </script>

--- a/public/pos.php
+++ b/public/pos.php
@@ -14,7 +14,10 @@ include __DIR__ . '/../src/header.php';
 <div class="row g-3">
   <?php foreach ($tables as $t): ?>
     <div class="col-6 col-sm-6 col-md-4 col-lg-3">
-      <div class="card h-100 shadow-sm rounded-4 text-center position-relative" 
+      <div class="card h-100 shadow-sm rounded-4 text-center position-relative table-card"
+           data-id="<?= $t['id'] ?>"
+           data-status="<?= $t['status'] ?>"
+           data-opened-at="<?= htmlspecialchars($t['opened_at'] ?? '') ?>"
            style="cursor:pointer;"
            onclick="window.location='order.php?table=<?= $t['id'] ?>'">
         <div class="card-body py-4 px-2 d-flex flex-column justify-content-center align-items-center">
@@ -74,5 +77,37 @@ include __DIR__ . '/../src/header.php';
   document.addEventListener('DOMContentLoaded', () => {
     updateTimers();
     setInterval(updateTimers, 1000);
+    initTableWatcher();
   });
+
+  const tableStates = {};
+  function initTableWatcher() {
+    document.querySelectorAll('.table-card').forEach(card => {
+      tableStates[card.dataset.id] = {
+        status: card.dataset.status,
+        opened_at: card.dataset.openedAt || ''
+      };
+    });
+    setInterval(checkTableUpdates, 5000);
+  }
+
+  async function checkTableUpdates() {
+    try {
+      const resp = await fetch('api_tables_status.php');
+      const data = await resp.json();
+      let changed = false;
+      data.forEach(t => {
+        const prev = tableStates[t.id];
+        const opened = t.opened_at || '';
+        if (!prev || prev.status !== t.status || prev.opened_at !== opened) {
+          changed = true;
+        }
+      });
+      if (changed) {
+        location.reload();
+      }
+    } catch (e) {
+      console.error(e);
+    }
+  }
 </script>


### PR DESCRIPTION
## Summary
- add `api_tables_status.php` to report table states
- add `api_order_version.php` to expose order item version hash
- poll these endpoints in `pos.php` and `order.php` and reload when data changes

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685d7e4169c483209a1bd00bd67c313f