### PR TITLE
Improve receipt layout

### DIFF
--- a/public/payment.php
+++ b/public/payment.php
@@ -35,7 +35,17 @@ $tot = $pdo->prepare("
 $tot->execute([$order_id]);
 $total = $tot->fetchColumn() ?: 0.00;
 
-// 4) Ödeme formuna POST gelirse işleme al
+// 4) Sipariş kalemlerini çek
+$itemStmt = $pdo->prepare(
+    "SELECT oi.quantity, oi.unit_price, p.name
+       FROM order_items oi
+       JOIN products p ON oi.product_id = p.id
+      WHERE oi.order_id = ?"
+);
+$itemStmt->execute([$order_id]);
+$items = $itemStmt->fetchAll(PDO::FETCH_ASSOC);
+
+// 5) Ödeme formuna POST gelirse işleme al
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $method = ($_POST['method'] ?? 'cash') === 'card' ? 'card' : 'cash';
 
@@ -69,37 +79,102 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     exit;
 }
 
-// 5) Görünüm
+// 6) Görünüm
 include __DIR__ . '/../src/header.php';
 ?>
 
+<style>
+  .receipt {
+    font-family: "Courier New", Courier, monospace;
+    border: 2px dashed var(--border-color);
+    padding: 1rem;
+    margin-bottom: 1.5rem;
+    max-width: 420px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .payment-form {
+    max-width: 420px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+  .receipt-table {
+    width: 100%;
+    border-collapse: collapse;
+    table-layout: fixed;
+  }
+  .receipt-table th,
+  .receipt-table td {
+    padding: 0.5rem;
+    border-bottom: 1px dashed var(--border-color);
+    word-break: break-word;
+  }
+  .receipt-table tfoot td {
+    font-weight: 700;
+  }
+</style>
+
 <div class="container my-5">
   <h1 class="text-center mb-4">Ödeme – Masa <?= htmlspecialchars($order['table_id']) ?></h1>
-  <p class="text-center"><strong>Toplam Tutar:</strong> <?= number_format($total,2) ?> ₺</p>
-
-  <!-- Ödeme Formu -->
-  <form method="post" style="max-width: 400px; margin: 0 auto;" class="shadow-lg p-4 rounded-4">
-    <div class="mb-4">
-      <label class="form-label">Ödeme Yöntemi:</label>
-      <div class="btn-group w-100 gap-3" role="group">
-        <input type="radio" class="btn-check" name="method" id="methodCash" value="cash" autocomplete="off" checked>
-        <label class="btn btn-outline-primary flex-fill" for="methodCash">
-          <span class="material-icons align-middle me-1">attach_money</span>
-          Nakit
-        </label>
-
-        <input type="radio" class="btn-check" name="method" id="methodCard" value="card" autocomplete="off">
-        <label class="btn btn-outline-primary flex-fill" for="methodCard">
-          <span class="material-icons align-middle me-1">credit_card</span>
-          Kredi Kartı
-        </label>
+  <div class="row justify-content-center g-5">
+    <div class="col-md-6">
+      <div class="receipt">
+        <table class="receipt-table">
+          <thead>
+            <tr>
+              <th>Ürün</th>
+              <th>Adet</th>
+          <th>Birim Fiyat</th>
+          <th>Tutar</th>
+        </tr>
+      </thead>
+      <tbody>
+        <?php foreach ($items as $it): $sub = $it['quantity'] * $it['unit_price']; ?>
+        <tr>
+          <td><?= htmlspecialchars($it['name']) ?></td>
+          <td><?= $it['quantity'] ?></td>
+          <td><?= number_format($it['unit_price'], 2) ?> ₺</td>
+          <td><?= number_format($sub, 2) ?> ₺</td>
+        </tr>
+        <?php endforeach; ?>
+      </tbody>
+      <tfoot>
+        <tr>
+          <td colspan="3"><strong>TOPLAM</strong></td>
+          <td><strong><?= number_format($total,2) ?> ₺</strong></td>
+        </tr>
+      </tfoot>
+    </table>
       </div>
+
+      <p class="text-center"><strong>Toplam Tutar:</strong> <?= number_format($total,2) ?> ₺</p>
     </div>
-    <div class="d-grid gap-2">
-      <button type="submit" class="btn btn-primary btn-lg">Ödeme Al &amp; Masayı Kapat</button>
-      <a href="order.php?table=<?= $order['table_id'] ?>" class="btn btn-secondary btn-lg">Geri Dön</a>
+    <div class="col-md-6">
+      <!-- Ödeme Formu -->
+      <form method="post" class="payment-form shadow-lg p-4 rounded-4">
+        <div class="mb-4">
+          <label class="form-label">Ödeme Yöntemi:</label>
+          <div class="btn-group w-100 gap-3" role="group">
+            <input type="radio" class="btn-check" name="method" id="methodCash" value="cash" autocomplete="off" checked>
+            <label class="btn btn-outline-primary flex-fill" for="methodCash">
+              <span class="material-icons align-middle me-1">attach_money</span>
+              Nakit
+            </label>
+
+            <input type="radio" class="btn-check" name="method" id="methodCard" value="card" autocomplete="off">
+            <label class="btn btn-outline-primary flex-fill" for="methodCard">
+              <span class="material-icons align-middle me-1">credit_card</span>
+              Kredi Kartı
+            </label>
+          </div>
+        </div>
+        <div class="d-grid gap-2">
+          <button type="submit" class="btn btn-primary btn-lg">Ödeme Al &amp; Masayı Kapat</button>
+          <a href="order.php?table=<?= $order['table_id'] ?>" class="btn btn-secondary btn-lg">Geri Dön</a>
+        </div>
+      </form>
     </div>
-  </form>
+  </div>
 </div>
 
 <?php include __DIR__ . '/../src/footer.php'; ?>


### PR DESCRIPTION
## Summary
- restructure payment page into side-by-side receipt and form on desktop
- constrain receipt table width and prevent overflow

## Testing
- `php -l public/payment.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d8db91060832095ff8b34a60717ea