### PR TITLE
Remove automatic order refresh on occupied tables

### DIFF
--- a/public/order.php
+++ b/public/order.php
@@ -123,7 +123,6 @@ if ($_SESSION['user_role'] === 'Admin' && !empty($items)) {
     $itemLogs = $logStmt->fetchAll(PDO::FETCH_ASSOC);
 }
 
-$orderVersion = sha1(json_encode($items));
 
 include __DIR__ . '/../src/header.php';
 ?>
@@ -533,23 +532,4 @@ function openAddProductModal(categoryId = 0) {
 document.getElementById('openAddProduct').addEventListener('click', () => openAddProductModal());
 </script>
 
-<script>
-  let orderVersion = "<?= $orderVersion ?>";
-  async function checkOrderUpdates() {
-    try {
-      const resp = await fetch('api_order_version.php?table=<?= $table_id ?>');
-      const data = await resp.json();
-      if (orderVersion && data.version !== orderVersion) {
-        location.reload();
-      } else {
-        orderVersion = data.version;
-      }
-    } catch (e) {
-      console.error(e);
-    }
-  }
-  document.addEventListener('DOMContentLoaded', () => {
-    setInterval(checkOrderUpdates, 5000);
-  });
-</script>
 


### PR DESCRIPTION
## Summary
- stop checking `api_order_version.php` on the order page so it no longer refreshes while viewing a table

## Testing
- `php -l public/order.php` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_685da8f884c08320b836d7165418902e