### PR TITLE
Center order page

### DIFF
--- a/public/order.php
+++ b/public/order.php
@@ -129,6 +129,9 @@ include __DIR__ . '/../src/header.php';
 
 <style>
 /* Garson Sipariş Sayfası Özel Stilleri */
+main.container {
+    max-width: 1000px;
+}
 .order-header {
     background: linear-gradient(135deg, var(--header-bg) 0%, rgba(37, 99, 235, 0.8) 100%);
     color: white;


### PR DESCRIPTION
## Summary
- narrow the layout for order.php for desktop usage

## Testing
- `php -l public/order.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685daf938954832092e70055564fa1b1