### PR TITLE
Improve confirm modal element detection

### DIFF
--- a/public/assets/css/styleson.css
+++ b/public/assets/css/styleson.css
@@ -870,3 +870,24 @@ html[data-theme="dark"] .navbar .d-flex button {
     width: 10%;
   }
 }
+
+/* Genel Popup Modalları */
+#alertModal .modal-content,
+#confirmModal .modal-content {
+  background: var(--container-bg) !important;
+  color: var(--text) !important;
+  border: 2px solid var(--border-color) !important;
+  border-radius: 16px !important;
+  box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25) !important;
+}
+
+#alertModal .modal-footer,
+#confirmModal .modal-footer {
+  border-top: none !important;
+  background: var(--container-bg) !important;
+}
+
+#alertModal .btn,
+#confirmModal .btn {
+  border-radius: 12px !important;
+}

--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -19,3 +19,77 @@ document.addEventListener('touchend', function (e) {
   }
   lastTouchEnd = now;
 }, false);
+
+// ----------- Genel Popup Fonksiyonlari -----------
+let alertModalInstance, confirmModalInstance;
+
+function showAlert(message, callback) {
+  const modalEl = document.getElementById('alertModal');
+  if (!modalEl) return alert(message);
+  modalEl.querySelector('.modal-body').textContent = message;
+  if (!alertModalInstance) {
+    alertModalInstance = new bootstrap.Modal(modalEl);
+  }
+  modalEl.querySelector('.ok-btn').onclick = function () {
+    alertModalInstance.hide();
+    if (callback) callback();
+  };
+  alertModalInstance.show();
+}
+
+function showConfirmModal(event, message) {
+  event.preventDefault();
+  const element =
+    (event.currentTarget || event.target).closest('a,button,input[type="submit"]');
+
+  const modalEl = document.getElementById('confirmModal');
+  if (!modalEl) {
+    if (confirm(message)) {
+      if (element && element.tagName === 'A') {
+        window.location = element.href;
+      } else if (element && element.form) {
+        if (typeof element.form.requestSubmit === 'function') {
+          element.form.requestSubmit(element);
+        } else {
+          const input = document.createElement('input');
+          input.type = 'hidden';
+          input.name = element.name;
+          input.value = element.value;
+          element.form.appendChild(input);
+          element.form.submit();
+        }
+      }
+    }
+    return false;
+  }
+
+  modalEl.querySelector('.modal-body').textContent = message;
+  if (!confirmModalInstance) {
+    confirmModalInstance = new bootstrap.Modal(modalEl);
+  }
+  const yesBtn = modalEl.querySelector('.yes-btn');
+  const noBtn = modalEl.querySelector('.no-btn');
+  yesBtn.onclick = function () {
+    confirmModalInstance.hide();
+    if (!element) return;
+    if (element.tagName === 'A') {
+      window.location = element.href;
+    } else if (element.form) {
+      if (typeof element.form.requestSubmit === 'function') {
+        element.form.requestSubmit(element);
+      } else {
+        const input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = element.name;
+        input.value = element.value;
+        element.form.appendChild(input);
+        element.form.submit();
+      }
+    }
+  };
+  noBtn.onclick = function () {
+    confirmModalInstance.hide();
+  };
+  confirmModalInstance.show();
+  return false;
+}

--- a/public/assets/js/order.js
+++ b/public/assets/js/order.js
@@ -55,7 +55,7 @@ function openAddProductModal(categoryId = 0) {
         })
         .catch(err => {
             console.error('Hata:', err);
-            alert('\u00dcr\u00fcnler y\u00fcklenirken bir hata olu\u015ftu.');
+            showAlert('\u00dcr\u00fcnler y\u00fcklenirken bir hata olu\u015ftu.');
         });
 }
 

--- a/public/categories.php
+++ b/public/categories.php
@@ -15,18 +15,12 @@ if (isset($_GET['delete'])) {
     } catch (PDOException $e) {
         // 1451 = FOREIGN KEY constraint violation
         if (isset($e->errorInfo[1]) && $e->errorInfo[1] == 1451) {
-            echo "<script>
-                    alert('Bu kategoride ekli ürün varken kategoriyi silemezsiniz.');
-                    window.location='categories.php';
-                  </script>";
-            exit;
+            $_SESSION['alert'] = 'Bu kategoride ekli ürün varken kategoriyi silemezsiniz.';
         } else {
-            echo "<script>
-                    alert('Silme hatası: " . addslashes($e->getMessage()) . "');
-                    window.location='categories.php';
-                  </script>";
-            exit;
+            $_SESSION['alert'] = 'Silme hatası: ' . $e->getMessage();
         }
+        header('Location: categories.php');
+        exit;
     }
 }
 
@@ -96,7 +90,7 @@ include __DIR__ . '/../src/header.php';
             <td>
               <a href="?delete=<?= $c['id'] ?>"
                  class="btn btn-danger btn-sm"
-                 onclick="return confirm('Bu kategoriyi silmek istediğinize emin misiniz?')">
+                 onclick="return showConfirmModal(event, 'Bu kategoriyi silmek istediğinize emin misiniz?')">
                  Sil
               </a>
             </td>

--- a/public/order.php
+++ b/public/order.php
@@ -25,7 +25,8 @@ $tableName = $stmtTableName->fetchColumn();
 // Vardiya kontrolü
 $shift = $pdo->query("SELECT * FROM shifts WHERE closed_at IS NULL ORDER BY opened_at DESC LIMIT 1")->fetch();
 if (!$shift) {
-    echo "<script>alert('Gün Başı alınmamış. Lütfen önce Gün Başı yapın.');window.location='dashboard.php';</script>";
+    $_SESSION['alert'] = 'Gün Başı alınmamış. Lütfen önce Gün Başı yapın.';
+    header('Location: dashboard.php');
     exit;
 }
 
@@ -70,7 +71,8 @@ if (isset($_GET['delete_item'])) {
 
     // Silme işlemi için yetki kontrolü
     if ($_SESSION['user_role'] === 'Garson' && $_SESSION['user_role'] !== 'Garson (Yetkili)') {
-        echo "<script>alert('Silme yetkiniz yok.');window.location='order.php?table={$table_id}';</script>";
+        $_SESSION['alert'] = 'Silme yetkiniz yok.';
+        header("Location: order.php?table={$table_id}");
         exit;
     }
 
@@ -190,9 +192,9 @@ include __DIR__ . '/../src/header.php';
                         <td><strong><?= number_format($subtotal, 2) ?> ₺</strong></td>
                         <td>
                             <?php if ($_SESSION['user_role'] === 'Admin' || $_SESSION['user_role'] === 'Garson (Yetkili)'): ?>
-                                <a href="?table=<?= $table_id ?>&delete_item=<?= $i['id'] ?>" 
-                                   class="delete-link" 
-                                   onclick="return confirm('Bu ürünü silmek istediğinize emin misiniz?')">
+                                <a href="?table=<?= $table_id ?>&delete_item=<?= $i['id'] ?>"
+                                   class="delete-link"
+                                   onclick="return showConfirmModal(event, 'Bu ürünü silmek istediğinize emin misiniz?')">
                                     <span class="material-icons">delete</span>
                                 </a>
                             <?php endif; ?>

--- a/public/order_add.php
+++ b/public/order_add.php
@@ -8,7 +8,8 @@ $table_id    = (int)($_GET['table'] ?? 0);
 $category_id = isset($_GET['category']) ? (int)$_GET['category'] : 0;
 
 if (!$table_id) {
-    echo "<script>alert('Ge\xE7ersiz i\x15Flem.');window.location='pos.php';</script>";
+    $_SESSION["alert"] = "Geçersiz işlem.";
+    header("Location: pos.php");
     exit;
 }
 

--- a/public/products.php
+++ b/public/products.php
@@ -141,7 +141,7 @@ include __DIR__ . '/../src/header.php';
               <a href="products_edit.php?id=<?= $p['id'] ?>" class="me-2 text-warning">Düzenle</a>
               <a href="?delete=<?= $p['id'] ?>"
                  class="text-danger"
-                 onclick="return confirm('Bu ürünü silmek istediğinize emin misiniz?')">Sil</a>
+                 onclick="return showConfirmModal(event, 'Bu ürünü silmek istediğinize emin misiniz?')">Sil</a>
             </td>
           </tr>
         <?php endforeach; ?>

--- a/public/shifts.php
+++ b/public/shifts.php
@@ -26,7 +26,8 @@ if (isset($_POST['close_shift']) && $openShift) {
     $occupied = $pdo->query("SELECT COUNT(*) FROM pos_tables WHERE status = 'occupied'")
                    ->fetchColumn();
     if ($occupied > 0) {
-        echo "<script>alert('Gün sonu için tüm masaların boş olması gerekir.');window.location='shifts.php';</script>";
+        $_SESSION['alert'] = 'Gün sonu için tüm masaların boş olması gerekir.';
+        header('Location: shifts.php');
         exit;
     }
 
@@ -88,14 +89,14 @@ include __DIR__ . '/../src/header.php';
   <div class="mb-4 text-center">
     <?php if (!$openShift): ?>
       <form method="post" class="d-inline">
-        <button type="submit" name="open_shift" class="btn btn-success btn-lg" onclick="return confirm('Gün Başı almak istediğinize emin misiniz?')">
+        <button type="submit" name="open_shift" class="btn btn-success btn-lg" onclick="return showConfirmModal(event, 'Gün Başı almak istediğinize emin misiniz?')">
           <span class="material-icons">event</span> Gün Başı Al
         </button>
       </form>
     <?php else: ?>
       <p><strong>Açık Shift:</strong> <?= htmlspecialchars($openShift['opened_at'] ?: '-', ENT_QUOTES, 'UTF-8') ?> (<?= htmlspecialchars($openShift['opened_by'] ?? '-', ENT_QUOTES, 'UTF-8') ?>)</p>
       <form method="post" class="d-inline">
-        <button type="submit" name="close_shift" class="btn btn-danger btn-lg" onclick="return confirm('Gün Sonu almak istediğinize emin misiniz?')">
+        <button type="submit" name="close_shift" class="btn btn-danger btn-lg" onclick="return showConfirmModal(event, 'Gün Sonu almak istediğinize emin misiniz?')">
           <span class="material-icons">event_busy</span> Gün Sonu Al
         </button>
       </form>

--- a/public/tables.php
+++ b/public/tables.php
@@ -29,17 +29,10 @@ if (isset($_GET['delete'])) {
     } catch (PDOException $e) {
         // FK ihlali kodu 1451 ise özel uyarı
         if (isset($e->errorInfo[1]) && $e->errorInfo[1] == 1451) {
-            echo "<script>
-                    alert('Bu masa üzerinde hâlâ açık sipariş(ler) var. Lütfen önce siparişleri kapatın.');
-                    window.location='tables.php';
-                  </script>";
+            echo "<script>document.addEventListener('DOMContentLoaded',function(){showAlert('Bu masa üzerinde hâlâ açık sipariş(ler) var. Lütfen önce siparişleri kapatın.',function(){window.location='tables.php';});});</script>";
             exit;
         }
-        // Diğer hatalarda dilerseniz genel bir uyarı:
-        echo "<script>
-                alert('Silme sırasında bir hata oluştu.');
-                window.location='tables.php';
-              </script>";
+        echo "<script>document.addEventListener('DOMContentLoaded',function(){showAlert('Silme sırasında bir hata oluştu.',function(){window.location='tables.php';});});</script>";
         exit;
     }
 }
@@ -93,7 +86,7 @@ include __DIR__ . '/../src/header.php';
               <?php endif; ?>
             </td>
             <td>
-              <a href="?delete=<?= $t['id'] ?>" class="text-danger" onclick="return confirm('Bu masayı silmek istediğinize emin misiniz?')">Sil</a>
+              <a href="?delete=<?= $t['id'] ?>" class="text-danger" onclick="return showConfirmModal(event, 'Bu masayı silmek istediğinize emin misiniz?')">Sil</a>
             </td>
           </tr>
         <?php endforeach; ?>

--- a/public/transfer.php
+++ b/public/transfer.php
@@ -22,7 +22,8 @@ $stmtOrder = $pdo->prepare(
 $stmtOrder->execute([$fromTable]);
 $order = $stmtOrder->fetch(PDO::FETCH_ASSOC);
 if (!$order) {
-    echo "<script>alert('Kaynak masada açık sipariş yok.');window.location='pos.php';</script>";
+    $_SESSION['alert'] = 'Kaynak masada açık sipariş yok.';
+    header('Location: pos.php');
     exit;
 }
 
@@ -43,7 +44,8 @@ $tables = $pdo->query(
 if ($_SERVER['REQUEST_METHOD'] === 'POST' && !empty($_POST['to_table'])) {
     $toTable = (int)$_POST['to_table'];
     if ($toTable == 1) {
-        echo "<script>alert('Kasa taşınamaz.');window.location='pos.php';</script>";
+        $_SESSION['alert'] = 'Kasa taşınamaz.';
+        header('Location: pos.php');
         exit;
     }
 

--- a/public/users.php
+++ b/public/users.php
@@ -92,7 +92,7 @@ include __DIR__ . '/../src/header.php';
           <td><?= htmlspecialchars($user['role']) ?></td>
           <td>
             <a href="user_edit.php?id=<?= $user['id'] ?>" class="btn btn-warning btn-sm">Düzenle</a>
-            <a href="?delete=<?= $user['id'] ?>" class="btn btn-danger btn-sm" onclick="return confirm('Bu kullanıcıyı silmek istediğinize emin misiniz?')">Sil</a>
+            <a href="?delete=<?= $user['id'] ?>" class="btn btn-danger btn-sm" onclick="return showConfirmModal(event, 'Bu kullanıcıyı silmek istediğinize emin misiniz?')">Sil</a>
           </td>
         </tr>
       <?php endforeach; ?>

--- a/src/footer.php
+++ b/src/footer.php
@@ -5,6 +5,38 @@
   <footer class="text-center py-3 mt-5 small text-white bg-dark shadow-sm" style="letter-spacing:0.01em;">
     &copy; <?= date('Y') ?> Cafe POS
   </footer>
+
+  <!-- Genel Uyarı Modalları -->
+  <div class="modal fade" id="alertModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-body text-center"></div>
+        <div class="modal-footer justify-content-center border-0">
+          <button type="button" class="btn btn-primary ok-btn" data-bs-dismiss="modal">Tamam</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="modal fade" id="confirmModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered">
+      <div class="modal-content">
+        <div class="modal-body text-center"></div>
+        <div class="modal-footer justify-content-center border-0">
+          <button type="button" class="btn btn-secondary no-btn" data-bs-dismiss="modal">Vazgeç</button>
+          <button type="button" class="btn btn-primary yes-btn">Evet</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <?php if (!empty($_SESSION['alert'])): ?>
+  <script>
+    document.addEventListener('DOMContentLoaded', function () {
+      showAlert(<?= json_encode($_SESSION['alert']) ?>);
+    });
+  </script>
+  <?php unset($_SESSION['alert']); endif; ?>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- support input submit buttons in the global confirm handler

## Testing
- ❌ `php -v` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_685e788e1f708320a695647570e2a659