### PR TITLE
Improve product modal loading

### DIFF
--- a/public/assets/js/order.js
+++ b/public/assets/js/order.js
@@ -37,20 +37,25 @@ function attachModalEvents(container) {
 const tableId = document.getElementById('order-data').dataset.tableId;
 
 function openAddProductModal(categoryId = 0) {
+    const modalBody = document.getElementById('modal-body-content');
+    modalBody.innerHTML =
+        '<div class="d-flex justify-content-center align-items-center p-5">' +
+        '<div class="spinner-border text-primary" role="status">' +
+        '<span class="visually-hidden">Y\u00fckleniyor...</span>' +
+        '</div></div>';
+
+    const modalTitle = document.querySelector('.modal-title');
+    modalTitle.innerHTML = '<span class="material-icons me-2">restaurant_menu</span>\u00dcr\u00fcn Seçin';
+
+    if (!productModal) {
+        productModal = new bootstrap.Modal(document.getElementById('addProductModal'), { keyboard: false });
+    }
+    productModal.show();
+
     fetch('order_add.php?table=' + tableId + '&category=' + categoryId)
         .then(res => res.text())
         .then(html => {
-            const modalBody = document.getElementById('modal-body-content');
             modalBody.innerHTML = html;
-
-            const modalTitle = document.querySelector('.modal-title');
-            modalTitle.innerHTML = '<span class="material-icons me-2">restaurant_menu</span>\u00dcr\u00fcn Seçin';
-
-            if (!productModal) {
-                productModal = new bootstrap.Modal(document.getElementById('addProductModal'), {keyboard:false});
-            }
-            productModal.show();
-
             attachModalEvents(modalBody);
         })
         .catch(err => {

--- a/public/order_add.php
+++ b/public/order_add.php
@@ -61,7 +61,7 @@ $products = $stmt->fetchAll(PDO::FETCH_ASSOC);
             <div class="product-card product-item" data-name="<?= htmlspecialchars($p['name']) ?>">
                 <div class="product-image">
                     <?php if (!empty($p['image'])): ?>
-                        <img src="<?= htmlspecialchars($p['image']) ?>" alt="<?= htmlspecialchars($p['name']) ?>">
+                        <img src="<?= htmlspecialchars($p['image']) ?>" alt="<?= htmlspecialchars($p['name']) ?>" loading="lazy" decoding="async">
                     <?php else: ?>
                         <span class="material-icons">restaurant</span>
                     <?php endif; ?>


### PR DESCRIPTION
## Summary
- lazy load product images
- show a spinner while product modal loads

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f287eb94483208749286ff8e2db1b