### PR TITLE
Improve product modal loading

### DIFF
--- a/public/assets/js/order.js
+++ b/public/assets/js/order.js
@@ -37,21 +37,47 @@ function attachModalEvents(container) {
 const tableId = document.getElementById('order-data').dataset.tableId;
 
 function openAddProductModal(categoryId = 0) {
+    const modalBody = document.getElementById('modal-body-content');
+
+    // Show loading spinner while fetching modal content
+    modalBody.innerHTML =
+        '<div class="d-flex justify-content-center align-items-center p-5">' +
+        '<div class="spinner-border text-primary" role="status" ' +
+        'style="width: 3rem; height: 3rem;">' +
+        '<span class="visually-hidden">Y\u00fckleniyor...</span>' +
+        '</div></div>';
+
+    const modalTitle = document.querySelector('.modal-title');
+    modalTitle.innerHTML = '<span class="material-icons me-2">restaurant_menu</span>\u00dcr\u00fcn Seçin';
+
+    // Load modal stylesheet on first use to avoid layout shift
+    if (!document.getElementById('order-add-style')) {
+        const link = document.createElement('link');
+        link.id = 'order-add-style';
+        link.rel = 'stylesheet';
+        link.href = '/assets/css/order_add.css';
+        document.head.appendChild(link);
+    }
+
+    if (!productModal) {
+        productModal = new bootstrap.Modal(document.getElementById('addProductModal'), { keyboard: false });
+    }
+    productModal.show();
+
+    const start = Date.now();
     fetch('order_add.php?table=' + tableId + '&category=' + categoryId)
         .then(res => res.text())
         .then(html => {
-            const modalBody = document.getElementById('modal-body-content');
-            modalBody.innerHTML = html;
-
-            const modalTitle = document.querySelector('.modal-title');
-            modalTitle.innerHTML = '<span class="material-icons me-2">restaurant_menu</span>\u00dcr\u00fcn Seçin';
-
-            if (!productModal) {
-                productModal = new bootstrap.Modal(document.getElementById('addProductModal'), {keyboard:false});
+            const elapsed = Date.now() - start;
+            const showContent = () => {
+                modalBody.innerHTML = html;
+                attachModalEvents(modalBody);
+            };
+            if (elapsed < 3000) {
+                setTimeout(showContent, 3000 - elapsed);
+            } else {
+                showContent();
             }
-            productModal.show();
-
-            attachModalEvents(modalBody);
         })
         .catch(err => {
             console.error('Hata:', err);

--- a/public/order_add.php
+++ b/public/order_add.php
@@ -59,9 +59,9 @@ $products = $stmt->fetchAll(PDO::FETCH_ASSOC);
     <div class="products-grid" id="productGrid">
         <?php foreach ($products as $p): ?>
             <div class="product-card product-item" data-name="<?= htmlspecialchars($p['name']) ?>">
-                <div class="product-image">
+                <div class="product-image" style="height:180px;overflow:hidden;">
                     <?php if (!empty($p['image'])): ?>
-                        <img src="<?= htmlspecialchars($p['image']) ?>" alt="<?= htmlspecialchars($p['name']) ?>">
+                        <img src="<?= htmlspecialchars($p['image']) ?>" alt="<?= htmlspecialchars($p['name']) ?>" loading="lazy" decoding="async">
                     <?php else: ?>
                         <span class="material-icons">restaurant</span>
                     <?php endif; ?>


### PR DESCRIPTION
## Summary
- keep spinner visible for at least three seconds when loading products
- preload modal stylesheet so layout doesn't shift
- give `.product-image` inline height to avoid full-screen flash

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f287eb94483208749286ff8e2db1b