### PR TITLE
Implement lazy loading for order images

### DIFF
--- a/public/assets/js/order.js
+++ b/public/assets/js/order.js
@@ -32,6 +32,20 @@ function attachModalEvents(container) {
     });
 
     initQuantityButtons(container);
+    lazyLoadImages(container);
+}
+
+function lazyLoadImages(container) {
+    container.querySelectorAll('.product-image img[data-src]').forEach(img => {
+        const holder = img.parentElement;
+        const src = img.getAttribute('data-src');
+        const loader = new Image();
+        loader.onload = function() {
+            img.src = src;
+            holder.classList.remove('loading');
+        };
+        loader.src = src;
+    });
 }
 
 const tableId = document.getElementById('order-data').dataset.tableId;

--- a/public/order_add.php
+++ b/public/order_add.php
@@ -59,9 +59,11 @@ $products = $stmt->fetchAll(PDO::FETCH_ASSOC);
     <div class="products-grid" id="productGrid">
         <?php foreach ($products as $p): ?>
             <div class="product-card product-item" data-name="<?= htmlspecialchars($p['name']) ?>">
-                <div class="product-image">
+                <div class="product-image<?= !empty($p['image']) ? ' loading' : '' ?>">
                     <?php if (!empty($p['image'])): ?>
-                        <img src="<?= htmlspecialchars($p['image']) ?>" alt="<?= htmlspecialchars($p['name']) ?>">
+                        <img src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs="
+                             data-src="<?= htmlspecialchars($p['image']) ?>"
+                             alt="<?= htmlspecialchars($p['name']) ?>">
                     <?php else: ?>
                         <span class="material-icons">restaurant</span>
                     <?php endif; ?>


### PR DESCRIPTION
## Summary
- lazily load product images in the add-order modal
- show a spinner until each product image loads

## Testing
- `php -l public/order_add.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2fba43188320a3d8f82bfa530cdd