### PR TITLE
Add quick quantity increase in order cart

### DIFF
--- a/public/assets/css/order_add.css
+++ b/public/assets/css/order_add.css
@@ -151,10 +151,11 @@
     border-radius: 8px;
     color: #fff;
     font-weight: bold;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
     cursor: pointer;
+    text-decoration: none;
 }
 
 .qty-btn.minus {

--- a/public/order.php
+++ b/public/order.php
@@ -103,6 +103,22 @@ if (isset($_GET['delete_item'])) {
     exit;
 }
 
+// Ürün adedini artırma
+if (isset($_GET['increase_item'])) {
+    $item_id = (int)$_GET['increase_item'];
+
+    $chk = $pdo->prepare("SELECT order_id FROM order_items WHERE id = ?");
+    $chk->execute([$item_id]);
+    $oid = $chk->fetchColumn();
+    if ($oid == $order_id) {
+        $pdo->prepare("UPDATE order_items SET quantity = quantity + 1 WHERE id = ?")
+            ->execute([$item_id]);
+    }
+
+    header("Location: order.php?table={$table_id}");
+    exit;
+}
+
 // Veri çekme
 $items = $pdo->prepare("SELECT oi.id, oi.quantity, oi.unit_price, p.name FROM order_items oi JOIN products p ON oi.product_id = p.id WHERE oi.order_id = ?");
 $items->execute([$order_id]);
@@ -186,6 +202,7 @@ include __DIR__ . '/../src/header.php';
                         <td><?= htmlspecialchars($i['name']) ?></td>
                         <td>
                             <span class="badge bg-primary rounded-pill"><?= $i['quantity'] ?></span>
+                            <a href="?table=<?= $table_id ?>&increase_item=<?= $i['id'] ?>" class="qty-btn plus ms-2">+</a>
                         </td>
                         <td><?= number_format($i['unit_price'], 2) ?> ₺</td>
                         <td><strong><?= number_format($subtotal, 2) ?> ₺</strong></td>


### PR DESCRIPTION
## Summary
- allow incrementing item counts directly from order.php
- style qty buttons for links and remove underline

## Testing
- `php -l public/order.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685f3ce9da388320bfe7657ffecf0c57