### PR TITLE
Add monthly sales chart to dashboard

### DIFF
--- a/public/api_sales_month.php
+++ b/public/api_sales_month.php
@@ -1,0 +1,49 @@
+<?php
+require __DIR__ . '/../config/init.php';
+require __DIR__ . '/../src/auth.php';
+requireRole(['Admin']);
+
+$year  = isset($_GET['year']) ? (int)$_GET['year'] : (int)date('Y');
+$month = isset($_GET['month']) ? (int)$_GET['month'] : (int)date('n');
+if ($month < 1 || $month > 12) { $month = (int)date('n'); }
+if ($year < 2000 || $year > 2100) { $year = (int)date('Y'); }
+
+$start = sprintf('%04d-%02d-01', $year, $month);
+$end   = date('Y-m-d', strtotime("$start +1 month"));
+
+$stmt = $pdo->prepare(
+    "SELECT DATE(paid_at) AS day,
+            SUM(amount) AS total,
+            SUM(CASE WHEN method='cash' THEN amount ELSE 0 END) AS cash_total,
+            SUM(CASE WHEN method='card' THEN amount ELSE 0 END) AS card_total
+       FROM payments
+      WHERE paid_at >= ? AND paid_at < ?
+      GROUP BY DATE(paid_at)
+      ORDER BY DATE(paid_at)"
+);
+$stmt->execute([$start, $end]);
+$rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+$daysInMonth = cal_days_in_month(CAL_GREGORIAN, $month, $year);
+$data = [];
+for ($i = 1; $i <= $daysInMonth; $i++) {
+    $data[$i] = ['total' => 0, 'cash' => 0, 'card' => 0];
+}
+foreach ($rows as $r) {
+    $day = (int)substr($r['day'], -2);
+    $data[$day] = [
+        'total' => (float)$r['total'],
+        'cash'  => (float)$r['cash_total'],
+        'card'  => (float)$r['card_total']
+    ];
+}
+
+$result = [
+    'days'  => array_keys($data),
+    'total' => array_column($data, 'total'),
+    'cash'  => array_column($data, 'cash'),
+    'card'  => array_column($data, 'card')
+];
+
+header('Content-Type: application/json');
+echo json_encode($result);

--- a/public/assets/js/dashboard.js
+++ b/public/assets/js/dashboard.js
@@ -1,0 +1,54 @@
+let salesChart;
+
+async function loadSales() {
+  const year  = document.getElementById('yearSelect').value;
+  const month = document.getElementById('monthSelect').value;
+  const resp  = await fetch(`api_sales_month.php?year=${year}&month=${month}`);
+  const data  = await resp.json();
+  renderChart(data);
+}
+
+function renderChart(data) {
+  const ctx = document.getElementById('salesChart').getContext('2d');
+  if (salesChart) salesChart.destroy();
+  salesChart = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: data.days,
+      datasets: [
+        {
+          label: 'Toplam',
+          data: data.total,
+          borderColor: 'white',
+          backgroundColor: 'rgba(255,255,255,0.5)'
+        },
+        {
+          label: 'Nakit',
+          data: data.cash,
+          borderColor: 'green',
+          backgroundColor: 'rgba(0,128,0,0.5)'
+        },
+        {
+          label: 'Kart',
+          data: data.card,
+          borderColor: 'blue',
+          backgroundColor: 'rgba(0,0,255,0.5)'
+        }
+      ]
+    },
+    options: {
+      responsive: true,
+      scales: {
+        y: {
+          beginAtZero: true
+        }
+      }
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('monthSelect').addEventListener('change', loadSales);
+  document.getElementById('yearSelect').addEventListener('change', loadSales);
+  loadSales();
+});

--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -16,7 +16,29 @@ $openShift = $pdo->query(
 
 include __DIR__ . '/../src/header.php';
 ?>
+
 <h2 class="text-center my-4">Admin Paneli</h2>
+
+<!-- Aylık Ciro Grafiği -->
+<div class="card shadow-sm rounded-4 mb-4">
+  <div class="card-body">
+    <div class="row g-2 mb-3 align-items-end">
+      <div class="col-auto">
+        <label for="monthSelect" class="form-label mb-0">Ay</label>
+        <select id="monthSelect" class="form-select">
+          <?php for ($m = 1; $m <= 12; $m++): ?>
+            <option value="<?= $m ?>" <?= $m == date('n') ? 'selected' : '' ?>><?= $m ?></option>
+          <?php endfor; ?>
+        </select>
+      </div>
+      <div class="col-auto">
+        <label for="yearSelect" class="form-label mb-0">Yıl</label>
+        <input type="number" id="yearSelect" class="form-control" value="<?= date('Y') ?>" min="2000" max="2100">
+      </div>
+    </div>
+    <canvas id="salesChart" height="100"></canvas>
+  </div>
+</div>
 
 <div class="row g-3">
   <div class="col-12 col-md-6">
@@ -61,4 +83,6 @@ include __DIR__ . '/../src/header.php';
   </div>
 </div>
 
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="/assets/js/dashboard.js"></script>
 <?php include __DIR__ . '/../src/footer.php'; ?>


### PR DESCRIPTION
## Summary
- show monthly revenue chart on `dashboard.php`
- fetch monthly totals via new `api_sales_month.php`
- add interactive chart logic in `dashboard.js`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f56f8b854832090299173ea51edf3