### PR TITLE
Make order quantity controls mobile friendly

### DIFF
--- a/public/assets/css/order_add.css
+++ b/public/assets/css/order_add.css
@@ -127,10 +127,10 @@
 }
 
 .quantity-input {
-    width: 60px;
+    width: 45px;
     padding: 0.5rem;
     border: 2px solid var(--border-color);
-    border-radius: 8px;
+    border-radius: 12px;
     text-align: center;
     font-size: 1rem;
     margin-bottom: 0;
@@ -148,7 +148,7 @@
     width: 32px;
     height: 32px;
     border: none;
-    border-radius: 8px;
+    border-radius: 50%;
     color: #fff;
     font-weight: bold;
     display: inline-flex;
@@ -253,14 +253,15 @@
         font-size: 0.9rem;
     }
 	
-	.qty-btn {
+        .qty-btn {
         width: 24px;
         height: 24px;
         font-size: 0.9rem;
+        border-radius: 50%;
     }
 
     .quantity-input {
-        width: 45px;
+        width: 36px;
         padding: 0.4rem;
         font-size: 0.9rem;
     }


### PR DESCRIPTION
## Summary
- tweak the quantity controls in the add-product modal
- make +/- buttons circular and shrink the input for better mobile fit

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685f59ca0da083208bb756041bb50edd