### PR TITLE
Improve quantity control styling

### DIFF
--- a/public/assets/css/order_add.css
+++ b/public/assets/css/order_add.css
@@ -127,10 +127,11 @@
 }
 
 .quantity-input {
-    width: 60px;
-    padding: 0.5rem;
+    width: 40px;
+    height: 40px;
+    padding: 0;
     border: 2px solid var(--border-color);
-    border-radius: 8px;
+    border-radius: 50%;
     text-align: center;
     font-size: 1rem;
     margin-bottom: 0;
@@ -145,10 +146,10 @@
 }
 
 .qty-btn {
-    width: 32px;
-    height: 32px;
+    width: 40px;
+    height: 40px;
     border: none;
-    border-radius: 8px;
+    border-radius: 50%;
     color: #fff;
     font-weight: bold;
     display: inline-flex;
@@ -253,16 +254,19 @@
         font-size: 0.9rem;
     }
 	
-	.qty-btn {
-        width: 24px;
-        height: 24px;
+    .qty-btn {
+        width: 30px;
+        height: 30px;
         font-size: 0.9rem;
+        border-radius: 50%;
     }
 
     .quantity-input {
-        width: 45px;
-        padding: 0.4rem;
+        width: 35px;
+        height: 35px;
+        padding: 0;
         font-size: 0.9rem;
+        border-radius: 50%;
     }
 
     .add-button .btn-text {

--- a/public/order_add.php
+++ b/public/order_add.php
@@ -77,7 +77,7 @@ $products = $stmt->fetchAll(PDO::FETCH_ASSOC);
                         <input type="hidden" name="product_id" value="<?= $p['id'] ?>">
                         <div class="quantity-box">
                             <button type="button" class="qty-btn minus">-</button>
-                            <input type="number" name="quantity" class="quantity-input" min="1" value="1">
+                            <input type="number" name="quantity" class="quantity-input" min="1" value="1" readonly>
                             <button type="button" class="qty-btn plus">+</button>
                         </div>
                         <button type="submit" name="add_product" class="add-button">


### PR DESCRIPTION
## Summary
- make order modal quantity inputs readonly
- use round quantity controls with + and - buttons

## Testing
- `php -l public/order_add.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f5b7ee6b083208437cfb6f548cee3