### PR TITLE
Restrict quantity input editing

### DIFF
--- a/public/assets/css/order_add.css
+++ b/public/assets/css/order_add.css
@@ -130,7 +130,7 @@
     width: 60px;
     padding: 0.5rem;
     border: 2px solid var(--border-color);
-    border-radius: 8px;
+    border-radius: 50%;
     text-align: center;
     font-size: 1rem;
     margin-bottom: 0;
@@ -148,7 +148,7 @@
     width: 32px;
     height: 32px;
     border: none;
-    border-radius: 8px;
+    border-radius: 50%;
     color: #fff;
     font-weight: bold;
     display: inline-flex;
@@ -263,6 +263,7 @@
         width: 45px;
         padding: 0.4rem;
         font-size: 0.9rem;
+        border-radius: 50%;
     }
 
     .add-button .btn-text {

--- a/public/order_add.php
+++ b/public/order_add.php
@@ -77,7 +77,7 @@ $products = $stmt->fetchAll(PDO::FETCH_ASSOC);
                         <input type="hidden" name="product_id" value="<?= $p['id'] ?>">
                         <div class="quantity-box">
                             <button type="button" class="qty-btn minus">-</button>
-                            <input type="number" name="quantity" class="quantity-input" min="1" value="1">
+                            <input type="number" name="quantity" class="quantity-input" min="1" value="1" readonly>
                             <button type="button" class="qty-btn plus">+</button>
                         </div>
                         <button type="submit" name="add_product" class="add-button">


### PR DESCRIPTION
## Summary
- round quantity controls
- make quantity input read-only to disable manual edits

## Testing
- `php -l public/order_add.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685f5f62423483209e44de8a2e6e0916