### PR TITLE
Add daily revenue chart

### DIFF
--- a/public/dashboard.php
+++ b/public/dashboard.php
@@ -14,9 +14,39 @@ $openShift = $pdo->query(
     "SELECT * FROM shifts WHERE closed_at IS NULL ORDER BY opened_at DESC LIMIT 1"
 )->fetch();
 
+// Son 7 gün için günlük ciro (nakit ve kart)
+$dailyStmt = $pdo->query(
+    "SELECT DATE(paid_at) AS day,
+            SUM(CASE WHEN method='cash' THEN amount ELSE 0 END) AS cash_total,
+            SUM(CASE WHEN method='card' THEN amount ELSE 0 END) AS card_total
+       FROM payments
+      WHERE paid_at >= DATE_SUB(CURDATE(), INTERVAL 6 DAY)
+      GROUP BY DATE(paid_at)
+      ORDER BY day ASC"
+);
+$dailyRows = $dailyStmt->fetchAll(PDO::FETCH_ASSOC);
+
+$days        = [];
+$cashTotals  = [];
+$cardTotals  = [];
+$totalTotals = [];
+foreach ($dailyRows as $r) {
+    $days[]       = $r['day'];
+    $cashTotals[] = (float)$r['cash_total'];
+    $cardTotals[] = (float)$r['card_total'];
+    $totalTotals[] = (float)$r['cash_total'] + (float)$r['card_total'];
+}
+
 include __DIR__ . '/../src/header.php';
 ?>
 <h2 class="text-center my-4">Admin Paneli</h2>
+
+<!-- Günlük Ciro Grafiği -->
+<div class="card shadow-sm rounded-4 mb-4">
+  <div class="card-body">
+    <canvas id="dailyChart" style="max-height:350px;"></canvas>
+  </div>
+</div>
 
 <div class="row g-3">
   <div class="col-12 col-md-6">
@@ -60,5 +90,49 @@ include __DIR__ . '/../src/header.php';
     </div>
   </div>
 </div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+const days = <?php echo json_encode($days); ?>;
+const totals = <?php echo json_encode($totalTotals); ?>;
+const cashes = <?php echo json_encode($cashTotals); ?>;
+const cards = <?php echo json_encode($cardTotals); ?>;
+
+new Chart(document.getElementById('dailyChart'), {
+  type: 'bar',
+  data: {
+    labels: days,
+    datasets: [
+      {
+        label: 'Toplam',
+        data: totals,
+        backgroundColor: 'rgba(255,255,255,0.5)',
+        borderColor: 'rgba(255,255,255,1)',
+        borderWidth: 1
+      },
+      {
+        label: 'Nakit',
+        data: cashes,
+        backgroundColor: 'rgba(16,185,129,0.5)',
+        borderColor: 'rgba(16,185,129,1)',
+        borderWidth: 1
+      },
+      {
+        label: 'Kart',
+        data: cards,
+        backgroundColor: 'rgba(59,130,246,0.5)',
+        borderColor: 'rgba(59,130,246,1)',
+        borderWidth: 1
+      }
+    ]
+  },
+  options: {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: { y: { beginAtZero: true } },
+    plugins: { legend: { position: 'bottom' } }
+  }
+});
+</script>
 
 <?php include __DIR__ . '/../src/footer.php'; ?>


### PR DESCRIPTION
## Summary
- compute daily cash & card totals on the dashboard
- show totals in a responsive chart using Chart.js

## Testing
- `php -l public/dashboard.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f5fd7a72083208eeb6da2b5d00f51