### PR TITLE
Fix merge list shows empty tables

### DIFF
--- a/public/merge.php
+++ b/public/merge.php
@@ -5,13 +5,12 @@ require __DIR__ . '/../src/auth.php';
 require __DIR__ . '/../src/logger.php';
 requireRole(['Admin','Garson']);
 
-// Mevcut dolu masaları çek (sipariş açık)
+// Mevcut dolu masaları çek (sadece dolu masalar listelensin)
 $tables = $pdo->query(
-    "SELECT t.id, t.name
-       FROM pos_tables t
-       JOIN orders o ON o.table_id = t.id AND o.status = 'open'
-      WHERE t.id != 1
-      ORDER BY t.id"
+    "SELECT id, name
+       FROM pos_tables
+      WHERE id != 1 AND status = 'occupied'
+      ORDER BY id"
 )->fetchAll(PDO::FETCH_ASSOC);
 
 $error = '';


### PR DESCRIPTION
## Summary
- filter tables for merge by `status='occupied'` so empty tables aren't listed

## Testing
- `php -l public/merge.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685fe6666dc48320b7c50aaf6d94524f