### PR TITLE
Enable adding multiple items without closing modal

### DIFF
--- a/public/api_add_product.php
+++ b/public/api_add_product.php
@@ -1,0 +1,58 @@
+<?php
+require __DIR__ . '/../config/init.php';
+require __DIR__ . '/../src/auth.php';
+requireRole(['Admin', 'Garson', 'Garson (Yetkili)']);
+$role = currentUserRole();
+
+$table_id   = (int)($_POST['table_id'] ?? 0);
+$product_id = (int)($_POST['product_id'] ?? 0);
+$qty        = isset($_POST['quantity']) ? max(1, (int)$_POST['quantity']) : 1;
+
+if (!$table_id || !$product_id) {
+    http_response_code(400);
+    echo json_encode(['error' => 'invalid']);
+    exit;
+}
+
+if ($table_id == 1 && !in_array($role, ['Admin','Garson (Yetkili)'])) {
+    http_response_code(403);
+    echo json_encode(['error' => 'forbidden']);
+    exit;
+}
+
+try {
+    $pdo->beginTransaction();
+
+    $stmt = $pdo->prepare("SELECT id FROM orders WHERE table_id = ? AND status = 'open' LIMIT 1");
+    $stmt->execute([$table_id]);
+    $order_id = $stmt->fetchColumn();
+    if (!$order_id) {
+        $pdo->prepare("INSERT INTO orders (table_id) VALUES (?)")->execute([$table_id]);
+        $order_id = $pdo->lastInsertId();
+    }
+
+    $chk = $pdo->prepare("SELECT id FROM order_items WHERE order_id = ? AND product_id = ?");
+    $chk->execute([$order_id, $product_id]);
+    if ($item = $chk->fetch()) {
+        $pdo->prepare("UPDATE order_items SET quantity = quantity + ? WHERE id = ?")
+            ->execute([$qty, $item['id']]);
+    } else {
+        $price = $pdo->prepare("SELECT price FROM products WHERE id = ?");
+        $price->execute([$product_id]);
+        $unit = $price->fetchColumn();
+        $pdo->prepare("INSERT INTO order_items (order_id, product_id, quantity, unit_price) VALUES (?, ?, ?, ?)")
+            ->execute([$order_id, $product_id, $qty, $unit]);
+    }
+
+    $pdo->prepare("UPDATE pos_tables SET status = 'occupied', opened_at = NOW() WHERE id = ? AND opened_at IS NULL")
+        ->execute([$table_id]);
+
+    $pdo->commit();
+
+    header('Content-Type: application/json');
+    echo json_encode(['success' => true]);
+} catch (Exception $e) {
+    $pdo->rollBack();
+    http_response_code(500);
+    echo json_encode(['error' => 'db']);
+}

--- a/public/api_order_cart.php
+++ b/public/api_order_cart.php
@@ -1,0 +1,95 @@
+<?php
+require __DIR__ . '/../config/init.php';
+require __DIR__ . '/../src/auth.php';
+requireRole(['Admin', 'Garson', 'Garson (Yetkili)']);
+$role = currentUserRole();
+
+$table_id = (int)($_GET['table'] ?? 0);
+if (!$table_id) {
+    http_response_code(400);
+    exit;
+}
+if ($table_id == 1 && !in_array($role, ['Admin','Garson (Yetkili)'])) {
+    http_response_code(403);
+    exit;
+}
+
+$stmt = $pdo->prepare("SELECT id FROM orders WHERE table_id = ? AND status = 'open' LIMIT 1");
+$stmt->execute([$table_id]);
+$order_id = $stmt->fetchColumn();
+$items = [];
+if ($order_id) {
+    $stmtItems = $pdo->prepare("SELECT oi.id, oi.quantity, oi.unit_price, p.name FROM order_items oi JOIN products p ON oi.product_id = p.id WHERE oi.order_id = ? ORDER BY oi.id");
+    $stmtItems->execute([$order_id]);
+    $items = $stmtItems->fetchAll(PDO::FETCH_ASSOC);
+}
+
+ob_start();
+?>
+<div class="cart-header">
+    <span class="material-icons">shopping_cart</span>
+    Sipariş Sepeti
+</div>
+<?php if (empty($items)): ?>
+    <div class="cart-empty">
+        <div class="material-icons">shopping_cart</div>
+        <p>Henüz ürün eklenmedi</p>
+        <small>Yukarıdaki butondan ürün eklemeye başlayın</small>
+    </div>
+<?php else: ?>
+    <table class="cart-table">
+        <thead>
+            <tr>
+                <th>Ürün</th>
+                <th>Adet</th>
+                <th>Birim Fiyat</th>
+                <th>Tutar</th>
+                <th>İşlem</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php
+            $total = 0;
+            foreach ($items as $i):
+                $subtotal = $i['quantity'] * $i['unit_price'];
+                $total += $subtotal;
+            ?>
+                <tr>
+                    <td><?= htmlspecialchars($i['name']) ?></td>
+                    <td class="qty-cell">
+                        <span class="badge bg-primary rounded-pill"><?= $i['quantity'] ?></span>
+                        <a href="?table=<?= $table_id ?>&increase_item=<?= $i['id'] ?>" class="qty-btn plus">+</a>
+                    </td>
+                    <td><?= number_format($i['unit_price'], 2) ?> ₺</td>
+                    <td><strong><?= number_format($subtotal, 2) ?> ₺</strong></td>
+                    <td>
+                        <?php if ($_SESSION['user_role'] === 'Admin' || $_SESSION['user_role'] === 'Garson (Yetkili)'): ?>
+                            <a href="?table=<?= $table_id ?>&delete_item=<?= $i['id'] ?>" class="delete-link" onclick="return confirm('Bu ürünü silmek istediğinize emin misiniz?')">
+                                <span class="material-icons">delete</span>
+                            </a>
+                        <?php endif; ?>
+                    </td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+        <tfoot>
+            <tr style="border-top: 3px solid var(--border-color);">
+                <td colspan="3"><strong>TOPLAM</strong></td>
+                <td><strong style="font-size: 1.2rem; color: var(--btn-bg);">
+                    <?= number_format($total, 2) ?> ₺
+                </strong></td>
+                <td></td>
+            </tr>
+        </tfoot>
+    </table>
+<?php endif; ?>
+<?php if (!empty($items) && ($role === 'Admin' || $role === 'Garson (Yetkili)')): ?>
+<a href="payment.php?order=<?= $order_id ?>" class="payment-button">
+    <span class="material-icons">payment</span>
+    Ödeme Al & Masayı Kapat
+</a>
+<?php endif; ?>
+<?php
+$html = ob_get_clean();
+header('Content-Type: text/html; charset=UTF-8');
+echo $html;

--- a/public/assets/js/order.js
+++ b/public/assets/js/order.js
@@ -32,9 +32,45 @@ function attachModalEvents(container) {
     });
 
     initQuantityButtons(container);
+
+    container.querySelectorAll('form').forEach(form => {
+        form.addEventListener('submit', handleAddProduct);
+    });
 }
 
 const tableId = document.getElementById('order-data').dataset.tableId;
+
+async function handleAddProduct(e) {
+    e.preventDefault();
+    const form = e.currentTarget;
+    const formData = new FormData(form);
+    formData.append('table_id', tableId);
+    try {
+        const resp = await fetch('api_add_product.php', {
+            method: 'POST',
+            body: formData
+        });
+        if (resp.ok) {
+            await reloadCart();
+            form.querySelector('.quantity-input').value = 1;
+        } else {
+            alert('Ürün eklenemedi');
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Ürün eklenirken hata oluştu');
+    }
+}
+
+async function reloadCart() {
+    try {
+        const resp = await fetch('api_order_cart.php?table=' + tableId, { cache: 'no-store' });
+        const html = await resp.text();
+        document.getElementById('cartWrapper').innerHTML = html;
+    } catch (err) {
+        console.error(err);
+    }
+}
 
 function openAddProductModal(categoryId = 0) {
     fetch('order_add.php?table=' + tableId + '&category=' + categoryId)

--- a/public/order.php
+++ b/public/order.php
@@ -168,7 +168,7 @@ include __DIR__ . '/../src/header.php';
 </div>
 
 <!-- Sipariş Sepeti -->
-<div class="cart-section">
+<div id="cartWrapper" class="cart-section">
     <div class="cart-header">
         <span class="material-icons">shopping_cart</span>
         Sipariş Sepeti


### PR DESCRIPTION
## Summary
- support async cart updates
- create API endpoints for adding products and fetching cart
- reload cart content after product addition
- keep popup open by intercepting form submit

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686028d7eb648320a882963d936c1915