### PR TITLE
Refine product add pop-up

### DIFF
--- a/public/assets/js/order.js
+++ b/public/assets/js/order.js
@@ -33,8 +33,10 @@ function attachModalEvents(container) {
 
     initQuantityButtons(container);
 
-    container.querySelectorAll('form').forEach(form => {
-        form.addEventListener('submit', handleAddProduct);
+    container.addEventListener('submit', (e) => {
+        if (e.target.closest('.add-product-form')) {
+            handleAddProduct(e);
+        }
     });
 }
 
@@ -42,7 +44,7 @@ const tableId = document.getElementById('order-data').dataset.tableId;
 
 async function handleAddProduct(e) {
     e.preventDefault();
-    const form = e.currentTarget;
+    const form = e.target.closest('.add-product-form');
     const formData = new FormData(form);
     formData.append('table_id', tableId);
     try {

--- a/public/order_add.php
+++ b/public/order_add.php
@@ -73,7 +73,7 @@ $products = $stmt->fetchAll(PDO::FETCH_ASSOC);
                 <div class="product-info">
                     <div class="product-name"><?= htmlspecialchars($p['name']) ?></div>
                     <div class="product-price"><?= number_format($p['price'], 2) ?> ₺</div>
-					<form method="post" action="order.php?table=<?= $table_id ?>">
+                                        <form method="post" class="add-product-form">
                         <input type="hidden" name="product_id" value="<?= $p['id'] ?>">
                         <div class="quantity-box">
                             <button type="button" class="qty-btn minus">-</button>


### PR DESCRIPTION
## Summary
- keep add-product modal open
- prevent form submission from refreshing page

## Testing
- `php -l public/order_add.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860342b5db88320983698b8f603bec8