### PR TITLE
Fix add button click handler

### DIFF
--- a/public/assets/js/order.js
+++ b/public/assets/js/order.js
@@ -33,16 +33,35 @@ function attachModalEvents(container) {
 
     initQuantityButtons(container);
 
-    container.querySelectorAll('form').forEach(form => {
+    // Attach submission handlers to forms loaded via AJAX
+    container.querySelectorAll('form.add-product-form').forEach(form => {
         form.addEventListener('submit', handleAddProduct);
+        form.dataset.handled = '1';
     });
 }
+
+// Fallback event delegation in case a form is inserted dynamically
+const addProductModalEl = document.getElementById('addProductModal');
+addProductModalEl.addEventListener('submit', (e) => {
+    const form = e.target.closest('.add-product-form');
+    if (form && !form.dataset.handled) {
+        handleAddProduct(e);
+    }
+});
+
+// Also capture clicks on the add buttons in case the form submission is blocked
+addProductModalEl.addEventListener('click', (e) => {
+    const btn = e.target.closest('.add-button');
+    if (btn) {
+        handleAddProduct(e);
+    }
+});
 
 const tableId = document.getElementById('order-data').dataset.tableId;
 
 async function handleAddProduct(e) {
     e.preventDefault();
-    const form = e.currentTarget;
+    const form = e.target.closest('.add-product-form');
     const formData = new FormData(form);
     formData.append('table_id', tableId);
     try {

--- a/public/order.php
+++ b/public/order.php
@@ -162,7 +162,7 @@ include __DIR__ . '/../src/header.php';
 
 <!-- Ürün Ekle -->
 <div class="category-section text-center">
-    <button id="openAddProduct" class="btn btn-primary btn-lg">
+    <button id="openAddProduct" class="btn btn-primary btn-lg" type="button">
         <span class="material-icons me-2">add</span>Ürün Ekle
     </button>
 </div>

--- a/public/order_add.php
+++ b/public/order_add.php
@@ -73,7 +73,7 @@ $products = $stmt->fetchAll(PDO::FETCH_ASSOC);
                 <div class="product-info">
                     <div class="product-name"><?= htmlspecialchars($p['name']) ?></div>
                     <div class="product-price"><?= number_format($p['price'], 2) ?> ₺</div>
-					<form method="post" action="order.php?table=<?= $table_id ?>">
+                                        <form method="post" action="javascript:void(0)" class="add-product-form">
                         <input type="hidden" name="product_id" value="<?= $p['id'] ?>">
                         <div class="quantity-box">
                             <button type="button" class="qty-btn minus">-</button>


### PR DESCRIPTION
## Summary
- capture click events on add product buttons so forms submit via JS

## Testing
- ❌ `php -l public/order.php` (command not found)
- ❌ `php -l public/order_add.php` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_6860342b5db88320983698b8f603bec8