### PR TITLE
Enable AJAX add-to-cart with JSON

### DIFF
--- a/public/api_add_product.php
+++ b/public/api_add_product.php
@@ -4,9 +4,15 @@ require __DIR__ . '/../src/auth.php';
 requireRole(['Admin', 'Garson', 'Garson (Yetkili)']);
 $role = currentUserRole();
 
-$table_id   = (int)($_POST['table_id'] ?? 0);
-$product_id = (int)($_POST['product_id'] ?? 0);
-$qty        = isset($_POST['quantity']) ? max(1, (int)$_POST['quantity']) : 1;
+$inputData = null;
+if (isset($_SERVER['CONTENT_TYPE']) && strpos($_SERVER['CONTENT_TYPE'], 'application/json') !== false) {
+    $json = file_get_contents('php://input');
+    $inputData = json_decode($json, true);
+}
+
+$table_id   = (int)($inputData['table_id'] ?? $_POST['table_id'] ?? 0);
+$product_id = (int)($inputData['product_id'] ?? $_POST['product_id'] ?? 0);
+$qty        = isset($inputData['quantity']) ? max(1, (int)$inputData['quantity']) : (isset($_POST['quantity']) ? max(1, (int)$_POST['quantity']) : 1);
 
 if (!$table_id || !$product_id) {
     http_response_code(400);
@@ -49,8 +55,28 @@ try {
 
     $pdo->commit();
 
+    // Fetch updated cart data
+    $stmtItems = $pdo->prepare(
+        "SELECT oi.id, oi.quantity, oi.unit_price, p.name
+           FROM order_items oi
+           JOIN products p ON oi.product_id = p.id
+          WHERE oi.order_id = ?
+       ORDER BY oi.id"
+    );
+    $stmtItems->execute([$order_id]);
+    $items = $stmtItems->fetchAll(PDO::FETCH_ASSOC);
+
+    $total = 0;
+    foreach ($items as &$it) {
+        $subtotal = $it['quantity'] * $it['unit_price'];
+        $it['subtotal'] = $subtotal;
+        $total += $subtotal;
+    }
+
+    $cart = [ 'items' => $items, 'total' => $total ];
+
     header('Content-Type: application/json');
-    echo json_encode(['success' => true]);
+    echo json_encode(['success' => true, 'cart' => $cart]);
 } catch (Exception $e) {
     $pdo->rollBack();
     http_response_code(500);

--- a/public/api_order_cart.php
+++ b/public/api_order_cart.php
@@ -24,6 +24,19 @@ if ($order_id) {
     $items = $stmtItems->fetchAll(PDO::FETCH_ASSOC);
 }
 
+$total = 0;
+foreach ($items as &$i) {
+    $subtotal = $i['quantity'] * $i['unit_price'];
+    $i['subtotal'] = $subtotal;
+    $total += $subtotal;
+}
+
+if (isset($_GET['format']) && $_GET['format'] === 'json') {
+    header('Content-Type: application/json');
+    echo json_encode(['cart' => ['items' => $items, 'total' => $total]]);
+    exit;
+}
+
 ob_start();
 ?>
 <div class="cart-header">
@@ -48,12 +61,7 @@ ob_start();
             </tr>
         </thead>
         <tbody>
-            <?php
-            $total = 0;
-            foreach ($items as $i):
-                $subtotal = $i['quantity'] * $i['unit_price'];
-                $total += $subtotal;
-            ?>
+            <?php foreach ($items as $i): ?>
                 <tr>
                     <td><?= htmlspecialchars($i['name']) ?></td>
                     <td class="qty-cell">
@@ -61,7 +69,7 @@ ob_start();
                         <a href="?table=<?= $table_id ?>&increase_item=<?= $i['id'] ?>" class="qty-btn plus">+</a>
                     </td>
                     <td><?= number_format($i['unit_price'], 2) ?> ₺</td>
-                    <td><strong><?= number_format($subtotal, 2) ?> ₺</strong></td>
+                    <td><strong><?= number_format($i['subtotal'], 2) ?> ₺</strong></td>
                     <td>
                         <?php if ($_SESSION['user_role'] === 'Admin' || $_SESSION['user_role'] === 'Garson (Yetkili)'): ?>
                             <a href="?table=<?= $table_id ?>&delete_item=<?= $i['id'] ?>" class="delete-link" onclick="return confirm('Bu ürünü silmek istediğinize emin misiniz?')">

--- a/public/assets/js/order.js
+++ b/public/assets/js/order.js
@@ -1,4 +1,5 @@
 let productModal;
+let toast;
 
 function initQuantityButtons(container) {
     container.querySelectorAll('.quantity-box').forEach(box => {
@@ -43,16 +44,22 @@ const tableId = document.getElementById('order-data').dataset.tableId;
 async function handleAddProduct(e) {
     e.preventDefault();
     const form = e.currentTarget;
-    const formData = new FormData(form);
-    formData.append('table_id', tableId);
+    const data = {
+        table_id: tableId,
+        product_id: form.querySelector('input[name="product_id"]').value,
+        quantity: form.querySelector('input[name="quantity"]').value
+    };
     try {
         const resp = await fetch('api_add_product.php', {
             method: 'POST',
-            body: formData
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data)
         });
-        if (resp.ok) {
-            await reloadCart();
+        const resData = await resp.json();
+        if (resp.ok && resData.success) {
+            updateCart(resData.cart);
             form.querySelector('.quantity-input').value = 1;
+            showToast('Ürün sepete eklendi');
         } else {
             alert('Ürün eklenemedi');
         }
@@ -64,12 +71,50 @@ async function handleAddProduct(e) {
 
 async function reloadCart() {
     try {
-        const resp = await fetch('api_order_cart.php?table=' + tableId, { cache: 'no-store' });
-        const html = await resp.text();
-        document.getElementById('cartWrapper').innerHTML = html;
+        const resp = await fetch('api_order_cart.php?table=' + tableId + '&format=json', { cache: 'no-store' });
+        const data = await resp.json();
+        if (data.cart) {
+            updateCart(data.cart);
+        }
     } catch (err) {
         console.error(err);
     }
+}
+
+function updateCart(cart) {
+    const wrapper = document.getElementById('cartWrapper');
+    let html = `<div class="cart-header"><span class="material-icons">shopping_cart</span> Sipariş Sepeti</div>`;
+    if (!cart.items || cart.items.length === 0) {
+        html += `<div class="cart-empty"><div class="material-icons">shopping_cart</div><p>Henüz ürün eklenmedi</p><small>Yukarıdaki butondan ürün eklemeye başlayın</small></div>`;
+    } else {
+        html += '<table class="cart-table"><thead><tr><th>Ürün</th><th>Adet</th><th>Birim Fiyat</th><th>Tutar</th><th>İşlem</th></tr></thead><tbody>';
+        cart.items.forEach(it => {
+            const subtotal = it.quantity * it.unit_price;
+            html += `<tr>`+
+                `<td>${escapeHtml(it.name)}</td>`+
+                `<td class="qty-cell"><span class="badge bg-primary rounded-pill">${it.quantity}</span>`+
+                `<a href="?table=${tableId}&increase_item=${it.id}" class="qty-btn plus">+</a></td>`+
+                `<td>${Number(it.unit_price).toFixed(2)} ₺</td>`+
+                `<td><strong>${subtotal.toFixed(2)} ₺</strong></td>`+
+                `<td><a href="?table=${tableId}&delete_item=${it.id}" class="delete-link" onclick="return confirm('Bu ürünü silmek istediğinize emin misiniz?')"><span class="material-icons">delete</span></a></td>`+
+                `</tr>`;
+        });
+        html += `</tbody><tfoot><tr style="border-top: 3px solid var(--border-color);"><td colspan="3"><strong>TOPLAM</strong></td><td><strong style="font-size: 1.2rem; color: var(--btn-bg);">${Number(cart.total).toFixed(2)} ₺</strong></td><td></td></tr></tfoot></table>`;
+    }
+    wrapper.innerHTML = html;
+}
+
+function escapeHtml(str) {
+    return str.replace(/[&<>"']/g, s => ({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[s]));
+}
+
+function showToast(msg) {
+    if (!toast) {
+        const el = document.getElementById('addToast');
+        toast = new bootstrap.Toast(el);
+    }
+    document.querySelector('#addToast .toast-body').textContent = msg;
+    toast.show();
 }
 
 function openAddProductModal(categoryId = 0) {

--- a/public/order.php
+++ b/public/order.php
@@ -278,7 +278,17 @@ include __DIR__ . '/../src/header.php';
     </div>
 </div>
 
-<?php include __DIR__ . '/../src/footer.php'; ?>
+<!-- Toast -->
+<div class="position-fixed bottom-0 end-0 p-3" style="z-index: 1100;">
+    <div id="addToast" class="toast align-items-center text-white bg-success border-0" role="alert" aria-live="assertive" aria-atomic="true">
+        <div class="d-flex">
+            <div class="toast-body">Ürün sepete eklendi</div>
+            <button type="button" class="btn-close btn-close-white me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>
+        </div>
+    </div>
+</div>
 
 <script src="/assets/js/order.js"></script>
+
+<?php include __DIR__ . '/../src/footer.php'; ?>
 


### PR DESCRIPTION
## Summary
- update `api_add_product.php` to accept JSON requests and respond with cart data
- allow `api_order_cart.php` to output JSON cart structure
- refactor `order.js` to send fetch requests with JSON and rebuild cart in DOM
- add Bootstrap toast for add-to-cart feedback
- ensure order page loads script before footer so JS executes

## Testing
- `php -l public/api_add_product.php` *(fails: command not found)*
- `php -l public/api_order_cart.php` *(fails: command not found)*
- `php -l public/order.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686042bc65e083208ce012f78e69f5c2