### PR TITLE
Remove modal for adding products

### DIFF
--- a/public/assets/js/order.js
+++ b/public/assets/js/order.js
@@ -1,4 +1,4 @@
-let productModal;
+let productSectionVisible = false;
 
 function initQuantityButtons(container) {
     container.querySelectorAll('.quantity-box').forEach(box => {
@@ -13,7 +13,7 @@ function initQuantityButtons(container) {
         });
     });
 }
-function attachModalEvents(container) {
+function attachSectionEvents(container) {
     const searchInput = container.querySelector('#productSearch');
     if (searchInput) {
         searchInput.addEventListener('input', function() {
@@ -27,7 +27,7 @@ function attachModalEvents(container) {
 
     container.querySelectorAll('.category-btn').forEach(btn => {
         btn.addEventListener('click', function() {
-            openAddProductModal(this.dataset.category);
+            openAddProductSection(this.dataset.category);
         });
     });
 
@@ -72,27 +72,28 @@ async function reloadCart() {
     }
 }
 
-function openAddProductModal(categoryId = 0) {
+function openAddProductSection(categoryId = 0) {
     fetch('order_add.php?table=' + tableId + '&category=' + categoryId)
         .then(res => res.text())
         .then(html => {
-            const modalBody = document.getElementById('modal-body-content');
-            modalBody.innerHTML = html;
-
-            const modalTitle = document.querySelector('.modal-title');
-            modalTitle.innerHTML = '<span class="material-icons me-2">restaurant_menu</span>\u00dcr\u00fcn Seçin';
-
-            if (!productModal) {
-                productModal = new bootstrap.Modal(document.getElementById('addProductModal'), {keyboard:false});
-            }
-            productModal.show();
-
-            attachModalEvents(modalBody);
+            const section = document.getElementById('addProductSection');
+            section.innerHTML = html;
+            section.style.display = 'block';
+            productSectionVisible = true;
+            attachSectionEvents(section);
         })
         .catch(err => {
             console.error('Hata:', err);
-            alert('\u00dcr\u00fcnler y\u00fcklenirken bir hata olu\u015ftu.');
+            alert('Ürünler yüklenirken bir hata oluştu.');
         });
 }
 
-document.getElementById('openAddProduct').addEventListener('click', () => openAddProductModal());
+document.getElementById('openAddProduct').addEventListener('click', () => {
+    const section = document.getElementById('addProductSection');
+    if (productSectionVisible) {
+        section.style.display = 'none';
+        productSectionVisible = false;
+    } else {
+        openAddProductSection();
+    }
+});

--- a/public/order.php
+++ b/public/order.php
@@ -123,7 +123,6 @@ if (isset($_GET['increase_item'])) {
 $items = $pdo->prepare("SELECT oi.id, oi.quantity, oi.unit_price, p.name FROM order_items oi JOIN products p ON oi.product_id = p.id WHERE oi.order_id = ?");
 $items->execute([$order_id]);
 $items = $items->fetchAll(PDO::FETCH_ASSOC);
-$products = $pdo->query("SELECT * FROM products ORDER BY sort_order IS NULL, sort_order, id")->fetchAll(PDO::FETCH_ASSOC);
 
 // Silinen ürün loglarını çek (sadece admin ve aktif ürün varsa)
 $itemLogs = [];
@@ -166,6 +165,7 @@ include __DIR__ . '/../src/header.php';
         <span class="material-icons me-2">add</span>Ürün Ekle
     </button>
 </div>
+<div id="addProductSection" class="mt-3" style="display:none;"></div>
 
 <!-- Sipariş Sepeti -->
 <div id="cartWrapper" class="cart-section">
@@ -260,23 +260,6 @@ include __DIR__ . '/../src/header.php';
 </div>
 <?php endif; ?>
 
-<!-- Popup Modal -->
-<div class="modal" tabindex="-1" id="addProductModal">
-    <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable modal-xl">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title">
-                    <span class="material-icons me-2">restaurant_menu</span>
-                    Ürün Seçin
-                </h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body" id="modal-body-content">
-                <!-- order_add.php içeriği burada dinamik olarak yüklenecek -->
-            </div>
-        </div>
-    </div>
-</div>
 
 <?php include __DIR__ . '/../src/footer.php'; ?>
 


### PR DESCRIPTION
## Summary
- show product selection inline on the order page instead of using a modal
- update JavaScript to fetch order_add.php content into a new section
- drop unused product query

## Testing
- `php -l public/order.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604c27c62883209c5e677056260439