### PR TITLE
Implement AJAX item increment

### DIFF
--- a/public/api_order_cart.php
+++ b/public/api_order_cart.php
@@ -58,7 +58,7 @@ ob_start();
                     <td><?= htmlspecialchars($i['name']) ?></td>
                     <td class="qty-cell">
                         <span class="badge bg-primary rounded-pill"><?= $i['quantity'] ?></span>
-                        <a href="?table=<?= $table_id ?>&increase_item=<?= $i['id'] ?>" class="qty-btn plus">+</a>
+                        <a href="?table=<?= $table_id ?>&increase_item=<?= $i['id'] ?>" class="qty-btn plus" data-item-id="<?= $i['id'] ?>">+</a>
                     </td>
                     <td><?= number_format($i['unit_price'], 2) ?> ₺</td>
                     <td><strong><?= number_format($subtotal, 2) ?> ₺</strong></td>

--- a/public/assets/js/order.js
+++ b/public/assets/js/order.js
@@ -1,5 +1,32 @@
 let productModal;
 
+function attachCartEvents(container) {
+    container.querySelectorAll('.qty-btn.plus').forEach(btn => {
+        btn.addEventListener('click', handleIncreaseItem);
+    });
+}
+
+async function handleIncreaseItem(e) {
+    e.preventDefault();
+    const itemId = e.currentTarget.dataset.itemId;
+    if (!itemId) return;
+
+    const formData = new FormData();
+    formData.append('item_id', itemId);
+
+    try {
+        const resp = await fetch('api_increase_item.php', { method: 'POST', body: formData });
+        if (resp.ok) {
+            updateOrderCart();
+        } else {
+            alert('Ürün eklenemedi');
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Ürün eklenirken hata oluştu');
+    }
+}
+
 function initQuantityButtons(container) {
     container.querySelectorAll('.quantity-box').forEach(box => {
         const input = box.querySelector('.quantity-input');
@@ -128,7 +155,9 @@ async function updateOrderCart() {
     try {
         const resp = await fetch('api_order_cart.php?table=' + tableId, { cache: 'no-store' });
         const html = await resp.text();
-        document.getElementById('cartWrapper').innerHTML = html;
+        const wrapper = document.getElementById('cartWrapper');
+        wrapper.innerHTML = html;
+        attachCartEvents(wrapper);
         
         // Ödeme butonunun görünürlüğünü kontrol et
         updatePaymentButtonVisibility();
@@ -176,3 +205,4 @@ function openAddProductModal(categoryId = 0) {
 }
 
 document.getElementById('openAddProduct').addEventListener('click', () => openAddProductModal());
+attachCartEvents(document.getElementById('cartWrapper'));

--- a/public/order.php
+++ b/public/order.php
@@ -202,7 +202,7 @@ include __DIR__ . '/../src/header.php';
                         <td><?= htmlspecialchars($i['name']) ?></td>
                         <td class="qty-cell">
                             <span class="badge bg-primary rounded-pill"><?= $i['quantity'] ?></span>
-                            <a href="?table=<?= $table_id ?>&increase_item=<?= $i['id'] ?>" class="qty-btn plus">+</a>
+                            <a href="?table=<?= $table_id ?>&increase_item=<?= $i['id'] ?>" class="qty-btn plus" data-item-id="<?= $i['id'] ?>">+</a>
                         </td>
                         <td><?= number_format($i['unit_price'], 2) ?> ₺</td>
                         <td><strong><?= number_format($subtotal, 2) ?> ₺</strong></td>


### PR DESCRIPTION
## Summary
- enable asynchronous increase in quantity for order items
- provide plus button with `data-item-id` in order cart
- update cart via AJAX after increasing item quantity

## Testing
- `php -l public/order.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68617394a97083209ab0192639e8e701