### PR TITLE
Add asynchronous item increment

### DIFF
--- a/public/api_increase_item.php
+++ b/public/api_increase_item.php
@@ -1,0 +1,45 @@
+<?php
+require __DIR__ . '/../config/init.php';
+require __DIR__ . '/../src/auth.php';
+requireRole(['Admin', 'Garson', 'Garson (Yetkili)']);
+$role = currentUserRole();
+
+$table_id = (int)($_POST['table_id'] ?? 0);
+$item_id  = (int)($_POST['item_id'] ?? 0);
+
+if (!$table_id || !$item_id) {
+    http_response_code(400);
+    echo json_encode(['error' => 'invalid']);
+    exit;
+}
+
+if ($table_id == 1 && !in_array($role, ['Admin','Garson (Yetkili)'])) {
+    http_response_code(403);
+    echo json_encode(['error' => 'forbidden']);
+    exit;
+}
+
+try {
+    $pdo->beginTransaction();
+    $chk = $pdo->prepare("SELECT oi.order_id FROM order_items oi JOIN orders o ON oi.order_id = o.id WHERE oi.id = ? AND o.table_id = ?");
+    $chk->execute([$item_id, $table_id]);
+    $order_id = $chk->fetchColumn();
+    if (!$order_id) {
+        $pdo->rollBack();
+        http_response_code(404);
+        echo json_encode(['error' => 'not_found']);
+        exit;
+    }
+
+    $pdo->prepare("UPDATE order_items SET quantity = quantity + 1 WHERE id = ?")
+        ->execute([$item_id]);
+
+    $pdo->commit();
+
+    header('Content-Type: application/json');
+    echo json_encode(['success' => true]);
+} catch (Exception $e) {
+    $pdo->rollBack();
+    http_response_code(500);
+    echo json_encode(['error' => 'db']);
+}

--- a/public/api_order_cart.php
+++ b/public/api_order_cart.php
@@ -58,7 +58,7 @@ ob_start();
                     <td><?= htmlspecialchars($i['name']) ?></td>
                     <td class="qty-cell">
                         <span class="badge bg-primary rounded-pill"><?= $i['quantity'] ?></span>
-                        <a href="?table=<?= $table_id ?>&increase_item=<?= $i['id'] ?>" class="qty-btn plus">+</a>
+                        <a href="#" class="qty-btn plus" data-item-id="<?= $i['id'] ?>">+</a>
                     </td>
                     <td><?= number_format($i['unit_price'], 2) ?> ₺</td>
                     <td><strong><?= number_format($subtotal, 2) ?> ₺</strong></td>

--- a/public/assets/js/order.js
+++ b/public/assets/js/order.js
@@ -129,7 +129,9 @@ async function updateOrderCart() {
         const resp = await fetch('api_order_cart.php?table=' + tableId, { cache: 'no-store' });
         const html = await resp.text();
         document.getElementById('cartWrapper').innerHTML = html;
-        
+
+        attachCartEvents();
+
         // Ödeme butonunun görünürlüğünü kontrol et
         updatePaymentButtonVisibility();
     } catch (err) {
@@ -176,3 +178,38 @@ function openAddProductModal(categoryId = 0) {
 }
 
 document.getElementById('openAddProduct').addEventListener('click', () => openAddProductModal());
+
+async function increaseCartItem(itemId) {
+    const formData = new FormData();
+    formData.append('table_id', tableId);
+    formData.append('item_id', itemId);
+
+    try {
+        const resp = await fetch('api_increase_item.php', {
+            method: 'POST',
+            body: formData
+        });
+        if (resp.ok) {
+            updateOrderCart();
+        } else {
+            alert('Ürün adedi artırılamadı');
+        }
+    } catch (err) {
+        console.error(err);
+        alert('Ürün adedi artırılırken hata oluştu');
+    }
+}
+
+function attachCartEvents() {
+    document.querySelectorAll('#cartWrapper .qty-btn.plus').forEach(btn => {
+        btn.addEventListener('click', function (e) {
+            e.preventDefault();
+            const itemId = this.dataset.itemId;
+            if (itemId) {
+                increaseCartItem(itemId);
+            }
+        });
+    });
+}
+
+document.addEventListener('DOMContentLoaded', attachCartEvents);

--- a/public/order.php
+++ b/public/order.php
@@ -202,7 +202,7 @@ include __DIR__ . '/../src/header.php';
                         <td><?= htmlspecialchars($i['name']) ?></td>
                         <td class="qty-cell">
                             <span class="badge bg-primary rounded-pill"><?= $i['quantity'] ?></span>
-                            <a href="?table=<?= $table_id ?>&increase_item=<?= $i['id'] ?>" class="qty-btn plus">+</a>
+                            <a href="#" class="qty-btn plus" data-item-id="<?= $i['id'] ?>">+</a>
                         </td>
                         <td><?= number_format($i['unit_price'], 2) ?> ₺</td>
                         <td><strong><?= number_format($subtotal, 2) ?> ₺</strong></td>


### PR DESCRIPTION
## Summary
- update plus button markup in order.php and api_order_cart.php
- add API endpoint to increase item quantity
- enhance order.js with functions to call new API and bind events

## Testing
- `php -l public/api_increase_item.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861c749f3f48320bc6b6f16807a8115