### PR TITLE
Clean header.php

### DIFF
--- a/src/header.php
+++ b/src/header.php
@@ -1,8 +1,5 @@
 <?php
 require __DIR__ . '/../config/init.php';
-
-$currentUrl = strtok($_SERVER['REQUEST_URI'], '?');
-
 $username = $_SESSION['username'] ?? '';
 $role     = $_SESSION['user_role'] ?? '';
 ?>


### PR DESCRIPTION
## Summary
- remove unused `$currentUrl` variable from `header.php`

## Testing
- `php -l src/header.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6861cc7a46a48320b4e8b213315283c4