### PR TITLE
Redirect logged in users from login

### DIFF
--- a/public/login.php
+++ b/public/login.php
@@ -3,6 +3,16 @@
 require __DIR__ . '/../config/init.php';
 require __DIR__ . '/../src/auth.php';
 
+// Kullanıcı zaten giriş yaptıysa rolüne göre yönlendir
+if (isLoggedIn()) {
+  if (currentUserRole() === 'Admin') {
+    header('Location: dashboard.php');
+  } else {
+    header('Location: pos.php');
+  }
+  exit;
+}
+
 $error = '';
 $rememberChecked = true; // Beni Hatırla varsayılan olarak işaretli
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {


### PR DESCRIPTION
## Summary
- redirect logged in users from `login.php` like `index.php`

## Testing
- `php -l public/login.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6861d574f4c48320b69c94b60e9b129a